### PR TITLE
SimulateDelay with Dynamic Localhost Port

### DIFF
--- a/server/temporal/activities.ts
+++ b/server/temporal/activities.ts
@@ -96,7 +96,7 @@ async function stripeCharge(amountCents: number,
 
 // call local simulateDelay API to simulate API downtime
 async function simulateDelay(seconds: number): Promise<string> {
-  const url = `http://localhost:3000/simulateDelay?s=${seconds}`; // Replace with your server URL
+  const url = `http://localhost:${configObj.port}/simulateDelay?s=${seconds}`; // Replace with your server URL
   console.log(`\n\n/API/simulateDelay URL: ${url}\n`);
 
   try {

--- a/server/temporal/config.ts
+++ b/server/temporal/config.ts
@@ -12,7 +12,8 @@ export interface ConfigObj {
     namespace: string,
     stripeSecretKey: string,
     prometheusAddress: string,
-    encryptPayloads: string
+    encryptPayloads: string,
+    port: string
 }
 
 // function that returns a ConfigObj with input environment variables
@@ -27,6 +28,7 @@ export function getConfig(): ConfigObj {
         stripeSecretKey: process.env.STRIPE_SECRET_KEY || '',
         prometheusAddress: process.env.PROMETHEUS_ADDRESS || '',
         encryptPayloads: process.env.ENCRYPT_PAYLOADS || 'false',
+        port: process.env.PORT || '3000'
     }
 }
 
@@ -41,6 +43,7 @@ export function printConfig(config: ConfigObj): void {
         namespace: ${config.namespace},
         prometheusAddress: ${config.prometheusAddress},
         encryptPayloads: ${config.encryptPayloads}
+        port: ${config.port}
     }`);
 }
 

--- a/server/temporal/config.ts
+++ b/server/temporal/config.ts
@@ -42,7 +42,7 @@ export function printConfig(config: ConfigObj): void {
         address: ${config.address},
         namespace: ${config.namespace},
         prometheusAddress: ${config.prometheusAddress},
-        encryptPayloads: ${config.encryptPayloads}
+        encryptPayloads: ${config.encryptPayloads},
         port: ${config.port}
     }`);
 }


### PR DESCRIPTION
I modify the simulateDelay() to dynamically fetch against a localhost dynamic/custom port from the .env files.